### PR TITLE
small changes for index

### DIFF
--- a/buch/papers/uebersicht.tex
+++ b/buch/papers/uebersicht.tex
@@ -321,7 +321,7 @@ und
 \index{Fabian Steiner}%
 \index{Steiner, Fabian}%
 gehen in Kapitel~\ref{chapter:wirbelringe} auf die Helmholtzschen
-\index{Wirbelsatz}%
+\index{Wirbelsaetze@Wirbelsätze}%
 \index{Helmholtz}%
 Wirbelsätze ein, die dieses und andere Wirbelphänomene verständlich
 machen.

--- a/buch/papers/wirbelringe/fig/wirbelringversuch.tex
+++ b/buch/papers/wirbelringe/fig/wirbelringversuch.tex
@@ -13,5 +13,6 @@
         \includegraphics[width=0.3\textwidth]{papers/wirbelringe/fig/versuch_moment_3.jpg}
     }
     \caption{3D Darstellung in Blender des gewünschten Versuchsausgangs.}
+    \index{Blender}
     \label{Wirbelringe:fig:wirbelringversuch}
 \end{figure}

--- a/buch/papers/wirbelringe/helmholtz.tex
+++ b/buch/papers/wirbelringe/helmholtz.tex
@@ -8,7 +8,7 @@
 \kopfrechts{Helmholtzsche Wirbelsätze}%
 Um das Verhalten von Wirbelringen besser zu verstehen, sind die sogenannten helmholtzschen Wirbelsätze sehr nützlich. 
 Mitte 19. Jahrhundert formulierte der deutsche Physiker Hermann von Helmholtz drei Wirbelsätze und veröffentlichte diese im Journal für die reine und angewandte Mathematik \cite{Wirbelringe:JournalHelmholtz}.
-\index{Wirbelsatze@Wirbelsätze}%
+\index{Wirbelsaetze@Wirbelsätze}%
 \index{Helmholtz, Hermann von}%
 In seinem veröffentlichten Paper definiert er auch die Begriffe Wirbellinie und Wirbelfaden, welche wir bereits kennen.
 


### PR DESCRIPTION
Im annotiertem Paper ist "Blender" markiert für den Index. Im Finalen Dokument ist "Blender" allerdings nicht im Index. Hinzugefügt.
Wirbelsatz und Wirbelsätze waren jeweils separat im Index:
<img width="327" height="149" alt="image" src="https://github.com/user-attachments/assets/9321a8c2-501d-43c9-8ac7-15c696b86aa5" />
Da auf Seite 311 auf die Wirbelsätze verwiesen wird macht es, meiner Meinung nach, mehr Sinn beide Indexeinträge zu vereinen.
<img width="539" height="149" alt="image" src="https://github.com/user-attachments/assets/ddd894be-83a4-4afd-86e1-ee1bb61f0b1c" />
Gibt es dazu (ungeschriebene) Konventionen?